### PR TITLE
Remove constraint for having at least two resolutions

### DIFF
--- a/video-quality-selector.js
+++ b/video-quality-selector.js
@@ -280,9 +280,6 @@
 			}
 		}
 		
-		// Make sure we have at least 2 available resolutions before we add the button
-		if ( available_res.length < 2 ) { return; }
-		
 		// Loop through the choosen default resolutions if there were any
 		for ( i = 0; i < default_resolutions.length; i++ ) {
 			


### PR DESCRIPTION
By default the resolution menu does not show if the video only has one resolution. But since we add a "Download Lecture" link to this menu, we need the menu to show.
